### PR TITLE
Add reusing checkpoints into `annotate_sex`

### DIFF
--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -22,6 +22,7 @@ from gnomad.utils.annotations import (
 from gnomad.utils.filtering import filter_low_conf_regions, filter_to_adj
 from gnomad.utils.reference_genome import get_reference_genome
 from gnomad.utils.sparse_mt import impute_sex_ploidy
+from gnomad.utils.file_utils import file_exists
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger(__name__)
@@ -373,16 +374,13 @@ def infer_sex_karyotype(
     return karyotype_ht
 
 
-def can_reuse_ht(
-    path: str,
-    overwrite: bool = False,
-) -> bool:
+def can_reuse_ht(fname: str, overwrite: bool = False) -> bool:
     """
-    Check if a Hail Table checkpoint at `path` exists and can be reused.
+    Check if a file at `path` exists and can be reused.
     """
     if overwrite:
         return False
-    if hl.hadoop_exists(os.path.join(path, "_SUCCESS")):
+    if file_exists(path):
         logger.info(f"Reusing checkpoint {path}")
         return True
     return False
@@ -390,7 +388,7 @@ def can_reuse_ht(
 
 T = TypeVar("T", str, None)
 
-def checkpoint_path(tmp_prefix: T, name: str) ->T:
+def checkpoint_path(tmp_prefix: T, name: str) -> T:
     """
     Path to save and read checkpoints.
     """

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -4,7 +4,7 @@ import functools
 import logging
 import operator
 import os
-from typing import List, Optional, Union
+from typing import List, Optional, Union, TypeVar
 
 import hail as hl
 

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -374,7 +374,7 @@ def infer_sex_karyotype(
     return karyotype_ht
 
 
-def can_reuse_ht(path: str, overwrite: bool = False) -> bool:
+def can_reuse(path: str, overwrite: bool = False) -> bool:
     """
     Check if a file at `path` exists and can be reused.
     """
@@ -486,7 +486,7 @@ def annotate_sex(
     :return: Table of samples and their imputed sex karyotypes.
     """
     logger.info("Imputing sex chromosome ploidies...")
-    if (path := checkpoint_path(tmp_prefix, "ploidy.ht")) and can_reuse_ht(path, overwrite):
+    if (path := checkpoint_path(tmp_prefix, "ploidy.ht")) and can_reuse(path, overwrite):
         ploidy_ht = hl.read_table(path)
     else:
         if infer_karyotype and not (compute_fstat or use_gaussian_mixture_model):
@@ -689,7 +689,7 @@ def annotate_sex(
             "Computing fraction of variants that are homozygous alternate on"
             " chromosome X"
         )
-        if (path := checkpoint_path(tmp_prefix, "compute_x_frac_variants_hom_alt.ht")) and can_reuse_ht(path, overwrite):
+        if (path := checkpoint_path(tmp_prefix, "compute_x_frac_variants_hom_alt.ht")) and can_reuse(path, overwrite):
             ploidy_ht = hl.read_table(path)
         else:
             filtered_mt = hl.filter_intervals(filtered_mt, x_locus_intervals)
@@ -716,7 +716,7 @@ def annotate_sex(
 
     if compute_fstat:
         logger.info("Filtering mt to biallelic SNPs in X contigs: %s", x_contigs)
-        if (path := checkpoint_path(tmp_prefix, "compute_fstat.ht")) and can_reuse_ht(path, overwrite):
+        if (path := checkpoint_path(tmp_prefix, "compute_fstat.ht")) and can_reuse(path, overwrite):
             ploidy_ht = hl.read_table(path)
         else:
             if "was_split" in list(mt.row):
@@ -757,7 +757,7 @@ def annotate_sex(
 
     if infer_karyotype:
         logger.info("infer_karyotype")
-        if (path := checkpoint_path(tmp_prefix, "infer_karyotype.ht")) and can_reuse_ht(path, overwrite):
+        if (path := checkpoint_path(tmp_prefix, "infer_karyotype.ht")) and can_reuse(path, overwrite):
             ploidy_ht = hl.read_table(path)
         else:
             karyotype_ht = infer_sex_karyotype(

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -374,7 +374,7 @@ def infer_sex_karyotype(
     return karyotype_ht
 
 
-def can_reuse_ht(fname: str, overwrite: bool = False) -> bool:
+def can_reuse_ht(path: str, overwrite: bool = False) -> bool:
     """
     Check if a file at `path` exists and can be reused.
     """


### PR DESCRIPTION
`annotate_sex` is a large multi-step pipeline prone to potential errors, that are hard to debug without extra checkpoints between steps. Adding support to pass a location for checkpoints explicitly, adding checkpoints between steps, and allow reusing existing checkpoints on reruns.

We might want to create an upstream PR as well.